### PR TITLE
Fix for windows linebreaks error

### DIFF
--- a/react.js
+++ b/react.js
@@ -31,6 +31,7 @@ module.exports = {
       'trailingComma': 'all',
       'arrowParens': 'always',
       'semi': false,
+      'endOfLine': 'auto',
     }],
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',


### PR DESCRIPTION
Fix for errors on windows due to line-break incompatibility
Expected line-breaks to be 'LF' but found 'CRLF'  linebreak-style
Delete `␍` eslint(prettier/prettier)