### PR TITLE
Enable react/self-closing-comp rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -24,6 +24,7 @@ module.exports = {
     '@typescript-eslint'
   ],
   rules: {
+    "react/self-closing-comp": "error",
     'prettier/prettier': ["error", {
       'printWidth': 80,
       'tabWidth': 2,


### PR DESCRIPTION
This is a code style optimization.

Issue:
When importing a component that has no content/children, ESLint is keep as <Example></Example> instead of self closing it as <Example />.

Solution:
Adding the rule ""react/self-closing-comp": "error"," to the ESLint config file will fix the self closing tag when saving the file.