### PR TITLE
React Eslint - ignore node_modules

### DIFF
--- a/react.js
+++ b/react.js
@@ -55,5 +55,8 @@ module.exports = {
     'import/parsers': {
       [require.resolve('@typescript-eslint/parser')]: ['.ts', '.tsx', '.d.ts'],
     },
-  }
+  },
+  ignorePatterns: [
+    'node_modules'
+  ]
 }


### PR DESCRIPTION
Added the field "ignorePatterns" to the React file so ESLint ignores the "node_modules" folder.

The goal is to improve the performance of lint checking, especially in the "format on save" situation.

Tested on:
- VSCode (Windows)
- Typescript react project 