### PR TITLE
Added Jest Env On Node Config

### DIFF
--- a/node.js
+++ b/node.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     es2021: true,
     node: true,
+    jest: true,
   },
   extends: ['standard', 'plugin:prettier/recommended'],
   parser: '@typescript-eslint/parser',


### PR DESCRIPTION
When using this configuration in projects with Jest, a `no-undef` error is generated in the test files.