### PR TITLE
fix: extends plugin:@typescript-eslint/recommended

### DIFF
--- a/react.js
+++ b/react.js
@@ -8,6 +8,7 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'standard',
+    'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
   ],
   parser: '@typescript-eslint/parser',


### PR DESCRIPTION
This pull request aims to extend a plugin that has already been installed, but has not been extended in the Eslint configuration.

Currently without this configuration Eslint does not allow writing TypeScript Enums, among other problems.