### PR TITLE
chore: add react/no-unknown-property ESLint rule

### DIFF
--- a/next.js
+++ b/next.js
@@ -43,6 +43,7 @@ module.exports = {
     'jsx-a11y/aria-unsupported-elements': 'warn',
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
+    'react/no-unknown-property': 'error',
   },
   settings: {
     react: {

--- a/react.js
+++ b/react.js
@@ -48,6 +48,7 @@ module.exports = {
     'jsx-a11y/aria-unsupported-elements': 'warn',
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
+    'react/no-unknown-property': 'error',
   },
   settings: {
     react: {


### PR DESCRIPTION
This rule translates the unknown properties of HTML to known properties in React.

Example:

![image](https://github.com/Rocketseat/eslint-config-rocketseat/assets/39345247/15371a00-2948-4efb-a559-ed3ad93a7648)
