### PR TITLE
Fix end of line errors

### DIFF
--- a/node.js
+++ b/node.js
@@ -20,6 +20,7 @@ module.exports = {
         trailingComma: 'all',
         arrowParens: 'always',
         semi: false,
+        endOfLine: 'auto',
       },
     ],
   },


### PR DESCRIPTION
Add "endOfLine" property in ESLint with Prettier to prevent errors in Node.js applications.