### PR TITLE
fix: windows linebreaks error

### DIFF
--- a/node.js
+++ b/node.js
@@ -20,6 +20,7 @@ module.exports = {
         trailingComma: 'all',
         arrowParens: 'always',
         semi: false,
+        endOfLine: 'auto',
       },
     ],
   },


### PR DESCRIPTION
Windows systems use the end of the CRLF line (Carriage Return + Line Feed, represented as \r\n).
Unix/Linux/macOS systems use the LF line ending (Line Feed, represented as \n).

Prettier, by default, forces the use of LF. When a file contains line endings in CRLF format (Windows), ESLint marks this as an error based on the prettier/prettier rule.